### PR TITLE
validate env vars and use older storage client

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ end
 
 By default, this plugin will automatically create the:
 
-* [resource group](Pluginazurerm)
+* [resource group](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/manage-resource-groups-portal)
 * [storage account](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-create?tabs=azure-portal)
 * [storage container](https://docs.microsoft.com/en-us/cli/azure/storage/container?view=azure-cli-latest#az-storage-container-create)
 
@@ -35,15 +35,17 @@ The settings generally only apply if the resource does not yet exist yet and is 
 
 ## Environment Variables
 
-To create the Azure resources like [resource group](Pluginazurerm), [storage account](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-create?tabs=azure-portal), and [storage container](https://docs.microsoft.com/en-us/cli/azure/storage/container?view=azure-cli-latest#az-storage-container-create) these environment variables are required:
+To create the Azure resources like [resource group](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/manage-resource-groups-portal), [storage account](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-create?tabs=azure-portal), and [storage container](https://docs.microsoft.com/en-us/cli/azure/storage/container?view=azure-cli-latest#az-storage-container-create) these environment variables are required:
 
-    AZURE_CLIENT_ID
-    AZURE_CLIENT_SECRET
+    ARM_CLIENT_ID
+    ARM_CLIENT_SECRET
 
-There's other env variables can also be set, but are generally inferred.
+Other env variables can be optionally set:
 
-    AZURE_TENANT_ID
-    AZURE_SUBSCRIPTION_ID
+    ARM_TENANT_ID
+    ARM_SUBSCRIPTION_ID
+
+When not set, their values are inferred from the [az cli](https://docs.microsoft.com/en-us/cli/azure/) settings. For those interested, this is done with the [boltops-tools/azure_info](https://github.com/boltops-tools/azure_info) library.
 
 ## Contributing
 

--- a/lib/terraspace_plugin_azurerm/clients/storage.rb
+++ b/lib/terraspace_plugin_azurerm/clients/storage.rb
@@ -6,8 +6,8 @@ module TerraspacePluginAzurerm::Clients
     extend Memoist
 
     # Include SDK modules to ease access to Storage classes.
-    include Azure::Storage::Profiles::Latest::Mgmt
-    include Azure::Storage::Profiles::Latest::Mgmt::Models
+    include Azure::Storage::Mgmt::V2019_06_01
+    include Azure::Storage::Mgmt::V2019_06_01::Models
 
     def storage_accounts
       mgmt.storage_accounts
@@ -19,7 +19,9 @@ module TerraspacePluginAzurerm::Clients
     memoize :blob_containers
 
     def mgmt
-      Client.new(client_options)
+      client = StorageManagementClient.new(credentials)
+      client.subscription_id = client_options[:subscription_id]
+      client
     end
     memoize :mgmt
   end


### PR DESCRIPTION
Looks like the latest version of azure_mgmt_storage-0.22.0 changed uses a new version of the Azure API that errors: `MsRestAzure::AzureOperationError: InvalidResourceType: The resource type 'checkNameAvailability' could not be found `

So using an old version of the azure storage client that works. 

Also, improve error checking for `ARM_CLIENT_ID` and `ARM_CLIENT_SECRET`. 

Allow both `ARM_*` and `AZURE_*` env vars to work, but favor `ARM_*` since that's what Terraform uses. https://www.terraform.io/docs/providers/azurerm/index.html