### PR TITLE
Add config.tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ TerraspacePluginAzurerm.configure do |config|
 
   config.storage_account.sku.name = "Standard_LRS"
   config.storage_account.sku.tier = "Standard"
+  config.storage_account.tags["Terraspace"] = "true"
+  config.storage_account.tags["Environment"] = "dev"
 end
 ```
 

--- a/lib/terraspace_plugin_azurerm/interfaces/backend/resource_group_creator.rb
+++ b/lib/terraspace_plugin_azurerm/interfaces/backend/resource_group_creator.rb
@@ -20,6 +20,7 @@ class TerraspacePluginAzurerm::Interfaces::Backend
       resource_group = ResourceGroup.new
       resource_group.name = @resource_group_name
       resource_group.location = config.location || AzureInfo.location
+      resource_group.tags = config.tags
       resource_groups.create_or_update(@resource_group_name, resource_group)
     end
 

--- a/lib/terraspace_plugin_azurerm/interfaces/backend/storage_account.rb
+++ b/lib/terraspace_plugin_azurerm/interfaces/backend/storage_account.rb
@@ -42,7 +42,7 @@ class TerraspacePluginAzurerm::Interfaces::Backend
       params.location = config.location || azure_info.location # IE: eastus
       params.sku = sku
       params.kind = Kind::StorageV2
-      params.tags = config.tags || {}
+      params.tags = config.tags
       params
     end
 

--- a/lib/terraspace_plugin_azurerm/interfaces/backend/storage_account.rb
+++ b/lib/terraspace_plugin_azurerm/interfaces/backend/storage_account.rb
@@ -42,6 +42,7 @@ class TerraspacePluginAzurerm::Interfaces::Backend
       params.location = config.location || azure_info.location # IE: eastus
       params.sku = sku
       params.kind = Kind::StorageV2
+      params.tags = config.tags || {}
       params
     end
 

--- a/lib/terraspace_plugin_azurerm/interfaces/config.rb
+++ b/lib/terraspace_plugin_azurerm/interfaces/config.rb
@@ -17,8 +17,8 @@ module TerraspacePluginAzurerm::Interfaces
       c.location = nil # AzureInfo.location not assigned here so it can be lazily inferred
       c.secrets = ActiveSupport::OrderedOptions.new
       c.secrets.vault = nil
+      c.tags = {}
       c.storage_account = ActiveSupport::OrderedOptions.new
-      c.storage_account.tags = {}
       c.storage_account.sku = ActiveSupport::OrderedOptions.new
       c.storage_account.sku.name = "Standard_LRS"
       c.storage_account.sku.tier = "Standard"

--- a/lib/terraspace_plugin_azurerm/interfaces/config.rb
+++ b/lib/terraspace_plugin_azurerm/interfaces/config.rb
@@ -18,6 +18,7 @@ module TerraspacePluginAzurerm::Interfaces
       c.secrets = ActiveSupport::OrderedOptions.new
       c.secrets.vault = nil
       c.storage_account = ActiveSupport::OrderedOptions.new
+      c.storage_account.tags = {}
       c.storage_account.sku = ActiveSupport::OrderedOptions.new
       c.storage_account.sku.name = "Standard_LRS"
       c.storage_account.sku.tier = "Standard"


### PR DESCRIPTION
This pull request adds the `tags` param to the plugin config.
This param adds the option to set tags to the backend resources through a Ruby Hash. 